### PR TITLE
real ip fix for badger

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -1,7 +1,7 @@
-displayName: Fossorial Badger
+displayName: gitmotion - Fossorial Badger
 type: middleware
 
-import: github.com/fosrl/badger
+import: github.com/gitmotion/fosrl-badger
 
 summary: Middleware auth bouncer for Pangolin
 
@@ -9,3 +9,26 @@ testData:
     apiBaseUrl: "http://localhost:3001/api/v1"
     userSessionCookieName: "p_session_token"
     resourceSessionRequestParam: "p_session_request"
+    TrustedIPs:
+        - "173.245.48.0/20" # Cloudflare IP ranges start
+        - "103.21.244.0/22"
+        - "103.22.200.0/22"
+        - "103.31.4.0/22"
+        - "141.101.64.0/18"
+        - "108.162.192.0/18"
+        - "190.93.240.0/20"
+        - "188.114.96.0/20"
+        - "197.234.240.0/22"
+        - "198.41.128.0/17"
+        - "162.158.0.0/15"
+        - "104.16.0.0/13"
+        - "104.24.0.0/14"
+        - "172.64.0.0/13"
+        - "131.0.72.0/22"
+        - "2400:cb00::/32"
+        - "2606:4700::/32"
+        - "2803:f800::/32"
+        - "2405:b500::/32"
+        - "2405:8100::/32" 
+        - "2a06:98c0::/29" 
+        - "2c0f:f248::/32" # Cloudflare IP ranges end

--- a/README.md
+++ b/README.md
@@ -18,6 +18,30 @@ Badger requires the following configuration parameters to be specified in your [
 apiBaseUrl: "http://localhost:3001/api/v1"
 userSessionCookieName: "p_session_token"
 resourceSessionRequestParam: "p_session_request"
+trustedIps:
+  - "173.245.48.0/20" # Cloudflare IP ranges start
+  - "103.21.244.0/22"
+  - "103.22.200.0/22"
+  - "103.31.4.0/22"
+  - "141.101.64.0/18"
+  - "108.162.192.0/18"
+  - "190.93.240.0/20"
+  - "188.114.96.0/20"
+  - "197.234.240.0/22"
+  - "198.41.128.0/17"
+  - "162.158.0.0/15"
+  - "104.16.0.0/13"
+  - "104.24.0.0/14"
+  - "172.64.0.0/13"
+  - "131.0.72.0/22"
+  - "2400:cb00::/32"
+  - "2606:4700::/32"
+  - "2803:f800::/32"
+  - "2405:b500::/32"
+  - "2405:8100::/32" 
+  - "2a06:98c0::/29" 
+  - "2c0f:f248::/32" # Cloudflare IP ranges end
+  - "10.0.0.1" # Single IP example
 ```
 
 ## License

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/fosrl/badger
+module github.com/gitmotion/fosrl-badger
 
 go 1.23.1


### PR DESCRIPTION
This PR introduces real IP extraction based on trusted IP ranges and updates module and configuration paths.

- Add `trustedIps` to `Config` and parse CIDR/single IP entries into in-memory structures.
- Implement `getRealIP` and `isTrustedIP` to honor common proxy headers for trusted sources.
- Update `README.md`, `.traefik.yml`, and `go.mod` to reflect the new config field and module path.

### Changes

| File           | Description                                                    |
| -------------- | -------------------------------------------------------------- |
| main.go        | Parse `trustedIps`, implement `isTrustedIP`/`getRealIP`, and use real IP in middleware bodies |
| go.mod         | Update module path from `github.com/fosrl/badger` to `github.com/gitmotion/fosrl-badger` |
| README.md      | Add `trustedIps` list for Cloudflare ranges and single IP example |
| .traefik.yml   | Update `displayName`, `import` path, and add `TrustedIPs` in testData |